### PR TITLE
NML2ChannelAnalyse can now be used more generally

### DIFF
--- a/Channelpedia/NML2ChannelAnalyse.py
+++ b/Channelpedia/NML2ChannelAnalyse.py
@@ -19,13 +19,25 @@ import airspeed
 import sys
 import os.path
 
-TEMPLATE_FILE = "LEMS_Test_template.xml"
+THIS_DIR = os.path.abspath(os.path.dirname(__file__))
+TEMPLATE_FILE = os.path.join(THIS_DIR,"LEMS_Test_template.xml")
     
 MAX_COLOUR = (255, 0, 0)
 MIN_COLOUR = (255, 255, 0)
 
 print("\n") 
 
+DEFAULTS = {'v': False,
+            'minV': -100,
+            'maxV': 100,
+            'temperature': 6.3,
+            'duration': 100,
+            'clampDelay': 10,
+            'clampDuration': 100,
+            'clampBaseVoltage': -70,
+            'stepTargetVoltage': 20,
+            'erev': 0,
+            'caConc': 5e-5}
 
 def process_args():
     """ 
@@ -41,67 +53,67 @@ def process_args():
                         
     parser.add_argument('-v',
                         action='store_true',
-                        default=False,
+                        default=DEFAULTS['v'],
                         help="Verbose output")
                         
     parser.add_argument('-minV', 
                         type=int,
                         metavar='<min v>',
-                        default=-100,
+                        default=DEFAULTS['minV'],
                         help='Minimum voltage to test (integer, mV)')
                         
     parser.add_argument('-maxV', 
                         type=int,
                         metavar='<max v>',
-                        default=100,
+                        default=DEFAULTS['maxV'],
                         help='Maximum voltage to test (integer, mV)')
                         
     parser.add_argument('-temperature', 
                         type=float,
                         metavar='<temperature>',
-                        default=6.3,
+                        default=DEFAULTS['temperature'],
                         help='Temperature (float, celsius)')
                         
     parser.add_argument('-duration', 
                         type=float,
                         metavar='<duration>',
-                        default=100,
+                        default=DEFAULTS['duration'],
                         help='Duration of simulation in ms')
                         
     parser.add_argument('-clampDelay', 
                         type=float,
                         metavar='<clamp delay>',
-                        default=10,
+                        default=DEFAULTS['clampDelay'],
                         help='Delay before voltage clamp is activated in ms')
                         
     parser.add_argument('-clampDuration', 
                         type=float,
                         metavar='<clamp duration>',
-                        default=80,
+                        default=DEFAULTS['clampDuration'],
                         help='Duration of voltage clamp in ms')
                         
     parser.add_argument('-clampBaseVoltage', 
                         type=float,
                         metavar='<clamp base voltage>',
-                        default=-70,
+                        default=DEFAULTS['clampBaseVoltage'],
                         help='Clamp base (starting/finishing) voltage in mV')
                         
     parser.add_argument('-stepTargetVoltage', 
                         type=float,
                         metavar='<step target voltage>',
-                        default=20,
+                        default=DEFAULTS['stepTargetVoltage'],
                         help='Voltage in mV through which to step voltage clamps')
                         
     parser.add_argument('-erev', 
                         type=float,
                         metavar='<reversal potential>',
-                        default=0,
+                        default=DEFAULTS['erev'],
                         help='Reversal potential of channel for currents')
                         
     parser.add_argument('-caConc', 
                         type=float,
                         metavar='<Ca2+ concentration>',
-                        default=5e-5,
+                        default=DEFAULTS['caConc'],
                         help='Internal concentration of Ca2+ (float, concentration in mM)')
                         
                         
@@ -161,15 +173,17 @@ def generate_lems_channel_analyser(channel_file, channel, min_target_voltage, \
 
     return merged
 
-def main():
+def main(args=None):
 
-    args = process_args()
-        
+    if args is None:
+        args = process_args()
+
     verbose = args.v
     
     ## Get name of channel mechanism to test
 
-    if verbose: print "Going to test channel from file: "+ args.channelFile
+    if verbose: 
+        print("Going to test channel from file: "+ args.channelFile)
     
     step_target_voltage = args.stepTargetVoltage
     clamp_delay = args.clampDelay 
@@ -182,10 +196,13 @@ def main():
         print("File could not be found: %s!\n"%args.channelFile)
         exit(1)
     doc = loaders.NeuroMLLoader.load(args.channelFile)
+    
     gates = []
     channels = []
-    for c in doc.ion_channel_hhs: channels.append(c)
-    for c in doc.ion_channel: channels.append(c)
+    for c in doc.ion_channel_hhs: 
+        channels.append(c)
+    for c in doc.ion_channel: 
+        channels.append(c)
     
     for ic in channels:
         print("Checking channel "+ic.id)
@@ -213,6 +230,7 @@ def main():
         
     print("Written generated LEMS file to %s\n"%new_lems_file)
     
+    return new_lems_file
     
 
 


### PR DESCRIPTION
This increases the generality of NML2ChannelAnalyse, allowing it to be used in a python script or function instead of just the command line.  An example of this new use is [here](https://github.com/scidash/neuronunit/blob/master/nml/jnml.py).  This will help support testing of channel models using SciUnit or otherwise.  This does not change the behavior of NML2ChannelAnalyse as used on the command line.   
